### PR TITLE
fixed chimney fires apparently offsetting changed?

### DIFF
--- a/Apex_framework_beta_103.terrain/code/config/QS_data_missionobjects.sqf
+++ b/Apex_framework_beta_103.terrain/code/config/QS_data_missionobjects.sqf
@@ -327,7 +327,7 @@ if (_worldName isEqualTo 'Altis') exitWith {
 				((missionNamespace getVariable 'QS_setFeatureType') + [[_chimney,2]]),
 				TRUE
 			];
-			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'NONE'];
+			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'CAN_COLLIDE'];
 			_fire allowDamage FALSE;
 			missionNamespace setVariable [
 				'QS_setFeatureType',
@@ -337,7 +337,7 @@ if (_worldName isEqualTo 'Altis') exitWith {
 			missionNamespace setVariable ['QS_torch',_fire,TRUE];
 			_fire enableDynamicSimulation FALSE;
 			_fire setVariable ['QS_dynSim_ignore',TRUE,TRUE];
-			_fire attachTo [_chimney,[-2,0,31]];
+			_fire attachTo [_chimney,[0,0,0]];
 			_fire spawn {
 				uiSleep 0.1;
 				detach _this;
@@ -702,7 +702,7 @@ if (_worldName isEqualTo 'Tanoa') exitWith {
 				((missionNamespace getVariable 'QS_setFeatureType') + [[_chimney,2]]),
 				TRUE
 			];
-			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'NONE'];
+			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'CAN_COLLIDE'];
 			_fire allowDamage FALSE;
 			missionNamespace setVariable [
 				'QS_setFeatureType',
@@ -712,7 +712,7 @@ if (_worldName isEqualTo 'Tanoa') exitWith {
 			missionNamespace setVariable ['QS_torch',_fire,TRUE];
 			_fire enableDynamicSimulation FALSE;
 			_fire setVariable ['QS_dynSim_ignore',TRUE,TRUE];
-			_fire attachTo [_chimney,[-2,0,31]];
+			_fire attachTo [_chimney,[0,0,0]];
 			_fire spawn {
 				uiSleep 0.1;
 				detach _this;
@@ -910,7 +910,7 @@ if (_worldName isEqualTo 'Malden') exitWith {
 				((missionNamespace getVariable 'QS_setFeatureType') + [[_chimney,2]]),
 				TRUE
 			];
-			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'NONE'];
+			_fire = createVehicle ['test_EmptyObjectForFireBig',[0,0,0],[],0,'CAN_COLLIDE'];
 			_fire allowDamage FALSE;
 			missionNamespace setVariable [
 				'QS_setFeatureType',
@@ -920,7 +920,7 @@ if (_worldName isEqualTo 'Malden') exitWith {
 			missionNamespace setVariable ['QS_torch',_fire,TRUE];
 			_fire enableDynamicSimulation FALSE;
 			_fire setVariable ['QS_dynSim_ignore',TRUE,TRUE];
-			_fire attachTo [_chimney,[-2,0,31]];
+			_fire attachTo [_chimney,[0,0,0]];
 			_fire spawn {
 				uiSleep 0.1;
 				detach _this;


### PR DESCRIPTION
the CAN_COLLIDE field might be needed... from my testing in eden spawning missionobjects.sqf the fire is always put on top of the chimney.  Nor is the Z height relevant it seems since the fire is attached to the chimney via attachTo its always put on top.  not sure why X was offset the fire would spawn off to the side.  I tried different Z values with no changes so submitting this as is (needs just a verification test)