### PR TITLE
Fix permanent deafness when removing earplugs

### DIFF
--- a/Apex_framework.terrain/code/functions/fn_clientEarplugs.sqf
+++ b/Apex_framework.terrain/code/functions/fn_clientEarplugs.sqf
@@ -1,9 +1,9 @@
 /*/
 File: fn_clientEarplugs.sqf
 Author:
-	
+
 	Quiksilver
-	
+
 Last Modified:
 
 	23/05/2023 A3 2.12 by Quiksilver
@@ -16,11 +16,11 @@ __________________________________________________________/*/
 if (diag_tickTime < (uiNamespace getVariable ['QS_earplugs_cooldown',-1])) exitWith {FALSE};
 uiNamespace setVariable ['QS_earplugs_cooldown',diag_tickTime + 0.5];
 playSoundUI ['ClickSoft',1,3,FALSE];
-getAudioOptionVolumes params ['_effects','','','','','_mapFactor'];
+getAudioOptionVolumes params ['','','','','','_mapFactor'];
 if (localNamespace getVariable ['QS_earplugs_toggle',FALSE]) then {
 	localNamespace setVariable ['QS_earplugs_toggle',FALSE];
 	(uiNamespace getVariable ['QS_client_uiCtrl_earplugs',controlNull]) ctrlShow FALSE;
-	0.4 fadeSound _effects;
+	0.4 fadeSound 1;
 } else {
 	localNamespace setVariable ['QS_earplugs_toggle',TRUE];
 	if ((profileNamespace getVariable ['QS_earplugs_hint',0]) < 10) then {
@@ -34,6 +34,6 @@ if (localNamespace getVariable ['QS_earplugs_toggle',FALSE]) then {
 		] call QS_fnc_hint;
 	};
 	(uiNamespace getVariable ['QS_client_uiCtrl_earplugs',controlNull]) ctrlShow TRUE;
-	0.4 fadeSound ((_effects * _mapFactor) min (_effects * 0.25));
+	0.4 fadeSound (_mapFactor min 0.25);
 };
 TRUE;


### PR DESCRIPTION
This PR fixes #42 by removing the effects volume from fadeSound calculations.

This may be considered a breaking change, as players who use earplugs may have compensated for the reduced volume by increasing their volume settings. Players that already have their effects volume at maximum (100%) will not be affected by this change.